### PR TITLE
Working hyperlink of contactUs.html added in the footer(Quick links)

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -140,7 +140,7 @@ function createFooter() {
                 <a href="index.html#abt-us">About Us</a><br>
                 <a href="teams.html">Team</a><br>
                 <a href="projects.html">Projects</a><br>
-                <a href="contactus.html">Contact Us</a><br>
+                <a href="contactUs.html">Contact Us</a><br>
             </section>
         </div>
         <hr style="border-top: 1px solid #f8f9fa;">


### PR DESCRIPTION
The hyperlink of contactUs.html present in Quick links was invalid (case sensitivity), I have replaced that hyperlink with the correct one.